### PR TITLE
Fix data for onError event in _evaluateAction for SCXML

### DIFF
--- a/lib/scion.js
+++ b/lib/scion.js
@@ -815,10 +815,26 @@
               return actionRef.call(this._scriptingContext, currentEvent);     //SCXML system variables
             } catch (e){
               var err = {
-                tagname: actionRef.tagname, 
-                line: actionRef.line, 
-                column: actionRef.column,
-                reason: e.message
+                reason: e.message,
+                event: currentEvent
+              };
+              if (typeof actionRef == 'function') {
+                var fnStr = actionRef.toString();
+                var m = fnStr.match(/line_([0-9]+)_column_([0-9]+)\(/);
+                if (m) {
+                  // SCXML
+                  err.line = parseInt(m[1]);
+                  err.column = parseInt(m[2]);
+                } else {
+                  // default
+                  err.actionRef = fnStr;
+                }
+              } else {
+                // I don't know when this can happen since actionRef.call() is always called before
+                // Kept it for backward compatibility but could/should remove it
+                err.tagname = actionRef.tagname;
+                err.line = actionRef.line;
+                err.column = actionRef.column;
               }
               this._internalEventQueue.push({"name":"error.execution",data : err});
               this.emit('onError', err);


### PR DESCRIPTION
The orginal code references `actionRef.tagname`, `actionRef.line` and `actionRef.column` which are not defined for SCXML statecharts. 
This makes possible to suscribe to the `onError` event with meaningfull error data for statechart built from SCXML (and using `scion` 1.1.3 from `SCION-CORE` master branch and not `scxml.scion` which references version 1.1.2). 