### PR TITLE
corrected passing in a _sessionid

### DIFF
--- a/lib/scion.js
+++ b/lib/scion.js
@@ -692,7 +692,7 @@ function BaseInterpreter(modelOrFnGenerator, opts){
 
     //SCXML system variables:
     this._x = {
-        _sessionId : opts.sessionId || null,
+        _sessionid : opts.sessionid || null,
         _name : model.name || opts.name || null,
         _ioprocessors : opts.ioprocessors || null
     };


### PR DESCRIPTION
seemed to me just like a small typo. Passing in a sessionid as InitArg works now. Chose small letters as defined in SCXML Specification.